### PR TITLE
Update GitHub Workflows

### DIFF
--- a/.github/workflows/cackle.yml
+++ b/.github/workflows/cackle.yml
@@ -23,15 +23,17 @@ env:
 jobs:
   cackle:
     name: Cackle check and test
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
       - uses: cackle-rs/cackle-action@latest
       # Note, we don't cache the target dir, since it currently wouldn't help. We also don't include
       # the toolchain or the OS in the cache key.
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,14 @@ env:
 jobs:
   test-stable:
     name: Test x86_64-linux stable
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
-      - uses: actions/cache@v3
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -34,14 +36,16 @@ jobs:
 
   clippy:
     name: Clippy
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       id: rust-toolchain
       with:
         components: clippy
-    - uses: actions/cache@v3
+    - uses: actions/cache@v5
       with:
         path: |
           ~/.cargo/bin/
@@ -54,9 +58,11 @@ jobs:
 
   rustfmt:
     name: Check formatting
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -14,9 +14,11 @@ jobs:
   cackle:
     if: github.repository == 'cackle-rs/cackle'
     name: cackle with latest
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: cackle-rs/cackle-action@latest
       - run: cargo update
@@ -26,9 +28,11 @@ jobs:
   test-nightly:
     if: github.repository == 'cackle-rs/cackle'
     name: Test Nightly
+    # bubblewrap is broken on Ubuntu 24.04
+    # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: dtolnay/rust-toolchain@nightly
       id: rust-toolchain
     - run: sudo apt update && sudo apt install git bubblewrap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        target: ${{ matrix.target }}
+    - uses: dtolnay/rust-toolchain@stable
 
     - name: Extract release notes
       shell: bash
@@ -38,10 +34,8 @@ jobs:
         awk "/# Version ${GITHUB_REF_NAME#v}/{flag=1; next} /^$/{flag=0} flag" RELEASE_NOTES.md >REL.md
 
     - name: Build release binary
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --target ${{ matrix.target }}
+      uses: dtolnay/rust-toolchain@stable
+    - run: cargo build --release --target ${{ matrix.target }}
 
     - name: Create tarballs (Unix)
       if: matrix.build == 'linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,14 @@ jobs:
       matrix:
         include:
         - build: linux
+          # bubblewrap is broken on Ubuntu 24.04
+          # update to ubuntu-latest once this is solved or Ubuntu 26.04 is available on GitHub
           os: ubuntu-22.04
           target: x86_64-unknown-linux-musl
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - uses: actions-rs/toolchain@v1
       with:
@@ -50,7 +52,7 @@ jobs:
         tar zcf $n.tar.gz $n
 
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         body_path: REL.md
         files: |


### PR DESCRIPTION
Updates action and OS versions in GitHub workflows.
Also replaces unmaintained actions.

This should also eliminate the warnings in the workflows about the soon to be end of life Node.js 20.