### PR TITLE
Update to Rust edition 2024

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ use symbol_graph::ScanOutputs;
 use tmpdir::TempDir;
 
 #[derive(Parser, Debug, Clone)]
-#[clap()]
+#[command()]
 struct OuterArgs {
     #[command(subcommand)]
     command: OuterCommand,
@@ -79,100 +79,100 @@ enum OuterCommand {
 }
 
 #[derive(Parser, Debug, Clone, Default)]
-#[clap(version, about)]
+#[command(version, about)]
 struct Args {
     /// Directory containing crate to analyze. Defaults to current working directory.
-    #[clap(long)]
+    #[arg(long)]
     path: Option<PathBuf>,
 
     /// Path to cackle.toml. Defaults to cackle.toml in the directory containing Cargo.toml.
-    #[clap(short, long)]
+    #[arg(short, long)]
     cackle_path: Option<PathBuf>,
 
     /// Print the mapping from paths to crate names. Useful for debugging.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     print_path_to_crate_map: bool,
 
     /// Promotes warnings (e.g. due to unused permissions) to errors.
-    #[clap(long)]
+    #[arg(long)]
     fail_on_warnings: bool,
 
     /// Ignore newer config versions.
-    #[clap(long)]
+    #[arg(long)]
     ignore_newer_config_versions: bool,
 
     /// Whether to use coloured output.
-    #[clap(long, alias = "color", default_value = "auto")]
+    #[arg(long, alias = "color", default_value = "auto")]
     colour: colour::Colour,
 
     /// Don't print anything on success.
-    #[clap(long)]
+    #[arg(long)]
     quiet: bool,
 
     /// Override the target used when compiling. e.g. "x86_64-unknown-linux-gnu".
-    #[clap(long)]
+    #[arg(long)]
     target: Option<String>,
 
     /// Override build profile.
-    #[clap(long)]
+    #[arg(long)]
     profile: Option<String>,
 
     /// Features to pass to cargo. Overrides common.features in config.
-    #[clap(long)]
+    #[arg(long)]
     features: Option<String>,
 
     /// Print how long various things take to run.
-    #[clap(long)]
+    #[arg(long)]
     print_timing: bool,
 
     /// Print additional information that's probably only useful for debugging.
-    #[clap(long)]
+    #[arg(long)]
     debug: bool,
 
     /// Output file for logs that might be useful for diagnosing problems.
-    #[clap(long)]
+    #[arg(long)]
     log_file: Option<PathBuf>,
 
     /// How detailed the logs should be.
-    #[clap(long, default_value = "info")]
+    #[arg(long, default_value = "info")]
     log_level: logging::LevelFilter,
 
     /// When specified, writes all requests into a subdirectory of the target directory. For
     /// debugging use.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     save_requests: bool,
 
     /// Instead of running `cargo build`, replay requests saved by a previous run where
     /// --write-requests was specified. For debugging use.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     replay_requests: bool,
 
     /// Temporary directory for Cackle to use. This is intended for testing purposes.
-    #[clap(long, hide = true)]
+    #[arg(long, hide = true)]
     tmpdir: Option<PathBuf>,
 
     /// What kind of user interface to use.
-    #[clap(long)]
+    #[arg(long)]
     ui: Option<ui::Kind>,
 
     /// Disable interactive UI.
-    #[clap(long, short)]
+    #[arg(long, short)]
     no_ui: bool,
 
     /// Automatically accept the default (first) fix for all problems.
     /// When multiple fixes are available, always applies the most sensible option.
     /// Useful for automated configuration generation.
-    #[clap(long)]
+    #[arg(long)]
     auto_accept_fixes: bool,
 
     /// Disable backtraces (may reduce peak memory consumption).
-    #[clap(long)]
+    #[arg(long)]
     no_backtrace: bool,
 
     // We may at some point allow this to be a short flag, but should probably wait a few releases.
     // -p was previously accepted for --path.
     /// Packages to build and analyse.
-    #[clap(long)]
+    #[arg(long)]
     package: Vec<String>,
 
     #[command(subcommand)]
@@ -190,13 +190,13 @@ enum Command {
     /// Run `cargo run`, analysing whatever gets built.
     Run(CargoOptions),
 
-    #[clap(hide = true, name = PROXY_BIN_ARG)]
+    #[command(hide = true, name = PROXY_BIN_ARG)]
     ProxyBin(ProxyBinOptions),
 }
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct ProxyBinOptions {
-    #[clap(allow_hyphen_values = true)]
+    #[arg(allow_hyphen_values = true)]
     remaining: Vec<String>,
 }
 

--- a/src/proxy/cargo.rs
+++ b/src/proxy/cargo.rs
@@ -10,7 +10,7 @@ pub(crate) const PROFILE_NAME_ENV: &str = "CACKLE_BUILD_PROFILE";
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct CargoOptions {
-    #[clap(allow_hyphen_values = true)]
+    #[arg(allow_hyphen_values = true)]
     remaining: Vec<String>,
 }
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -27,33 +27,33 @@ pub enum OutputFormat {
 #[derive(Parser, Debug, Clone)]
 pub(crate) struct SummaryOptions {
     /// Print summary by package.
-    #[clap(long)]
+    #[arg(long)]
     by_package: bool,
 
     /// Print summary by permission.
-    #[clap(long)]
+    #[arg(long)]
     by_permission: bool,
 
     /// Call out proc macros with other permissions.
-    #[clap(long)]
+    #[arg(long)]
     impure_proc_macros: bool,
 
     /// Print counts.
-    #[clap(long)]
+    #[arg(long)]
     counts: bool,
 
     /// Print all summary kinds. This is the default if no options are specified.
-    #[clap(long)]
+    #[arg(long)]
     full: bool,
 
     /// Whether to print headers for each summary section. This is forced on if more than one
     /// summary is selected.
-    #[clap(long)]
+    #[arg(long)]
     print_headers: bool,
 
     /// The format of the output
-    #[clap(long, value_enum, action)]
-    #[clap(default_value_t = OutputFormat::Human)]
+    #[arg(long, value_enum)]
+    #[arg(default_value_t = OutputFormat::Human)]
     output_format: OutputFormat,
 }
 

--- a/test_crates/crab-1/src/lib.rs
+++ b/test_crates/crab-1/src/lib.rs
@@ -28,7 +28,7 @@ pub fn do_network_stuff() {
 }
 
 /// This function shows up in the dynamic symbols of shared1, so should count as used.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn crab_1_entry() {
     println!("{:?}", std::env::var("HOME"));
 }

--- a/test_crates/crab-10/src/lib.rs
+++ b/test_crates/crab-10/src/lib.rs
@@ -1,4 +1,4 @@
-extern "C" {
+unsafe extern "C" {
     fn cpp_entry_point() -> i32;
 }
 

--- a/test_crates/crab-2/src/lib.rs
+++ b/test_crates/crab-2/src/lib.rs
@@ -16,7 +16,7 @@ pub mod stuff {
         kind = "static",
         modifiers = "-bundle,+whole-archive"
     )]
-    extern "C" {}
+    unsafe extern "C" {}
 
     pub fn do_stuff() {
         let crab_2_env = env!("CRAB_2_ENV");

--- a/test_crates/crab-3/src/lib.rs
+++ b/test_crates/crab-3/src/lib.rs
@@ -7,7 +7,7 @@ macro_rules! foo {
 
 #[macro_export]
 macro_rules! macro_that_uses_unsafe {
-    ($a:expr) => {
+    ($a:expr_2021) => {
         let v = $a;
         let mut x = 0_u32;
         if v {

--- a/test_crates/crab-7/src/lib.rs
+++ b/test_crates/crab-7/src/lib.rs
@@ -12,6 +12,6 @@ extern "C" fn before_main() {
     }
 }
 
-#[link_section = ".init_array"]
+#[unsafe(link_section = ".init_array")]
 #[used]
 static INIT_ARRAY: [extern "C" fn(); 1] = [before_main];

--- a/test_crates/crab-bin/src/main.rs
+++ b/test_crates/crab-bin/src/main.rs
@@ -38,7 +38,7 @@ fn function_with_custom_attr() -> i32 {
     40
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 fn non_mangled_function() {
     // Make sure we don't miss function references from non-mangled functions.
     println!("{:?}", std::env::var("HOME"));

--- a/test_crates/shared-1/src/lib.rs
+++ b/test_crates/shared-1/src/lib.rs
@@ -1,10 +1,10 @@
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn shared1_entry1() {
     let v = ["a.txt"];
     crab_1::read_file(v[0]);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn shared1_entry2() {
     println!("{:?}", std::env::var("HOME"));
     crab_2::stuff::do_stuff();


### PR DESCRIPTION
Partially addresses #37 

Backwards-incompatible changes:
- Accept shorter [`if let` temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-if-let-scope.html) as discussed in https://github.com/cackle-rs/cackle/pull/38#discussion_r3129594496
- Accept new [macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html) - to be discussed
- Accept shorter [tail expression temporary scope](https://doc.rust-lang.org/edition-guide/rust-2024/temporary-tail-expr-scope.html) as discussed in https://github.com/cackle-rs/cackle/pull/38#discussion_r3129342933
- Only set environment variables on child process to avoid unsafe - as discussed in https://github.com/cackle-rs/cackle/pull/38#discussion_r3157414945

Builds on #38 , so should be merged afterwards.