### PR TITLE
Improve API definitions

### DIFF
--- a/cackle.toml
+++ b/cackle.toml
@@ -70,7 +70,6 @@ allow_proc_macro = true
 allow_unsafe = true
 
 [pkg.serde]
-allow_unsafe = true
 allow_apis = [
     "fs",
 ]
@@ -198,9 +197,6 @@ build.allow_apis = [
 [pkg.twox-hash]
 allow_unsafe = true
 
-[pkg.stable_deref_trait]
-allow_unsafe = true
-
 [pkg.winnow]
 allow_unsafe = true
 
@@ -222,16 +218,10 @@ allow_unsafe = true
 [pkg.ruzstd]
 allow_unsafe = true
 
-[pkg.toml_edit]
-allow_unsafe = true
-
 [pkg.memchr]
 allow_unsafe = true
 
 [pkg.once_cell]
-allow_unsafe = true
-
-[pkg.addr2line]
 allow_unsafe = true
 
 [pkg.object]
@@ -257,7 +247,6 @@ test.sandbox.make_writable = [
     "test_crates/custom_target_dir",
 ]
 test.sandbox.allow_network = true
-test.allow_unsafe = true
 
 [pkg.clap_builder]
 allow_apis = [

--- a/src/config/built_in.rs
+++ b/src/config/built_in.rs
@@ -45,6 +45,7 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
         perm(
             &[
                 "std::process",
+                "std::os::linux::process",
                 "std::unix::process",
                 "std::windows::process",
             ],

--- a/src/config/built_in.rs
+++ b/src/config/built_in.rs
@@ -10,6 +10,7 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
         perm(
             &[
                 "std::fs",
+                "std::os::darwin::fs",
                 "std::os::linux::fs",
                 "std::os::unix::fs",
                 "std::os::unix::io",

--- a/src/config/built_in.rs
+++ b/src/config/built_in.rs
@@ -27,7 +27,12 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
     result.insert(
         ApiName::from("net"),
         perm(
-            &["std::net", "std::os::wasi::net", "std::os::windows::net"],
+            &[
+                "std::net",
+                "std::os::linux::net",
+                "std::os::wasi::net",
+                "std::os::windows::net",
+            ],
             &[],
         ),
     );

--- a/src/config/built_in.rs
+++ b/src/config/built_in.rs
@@ -27,12 +27,7 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
     result.insert(
         ApiName::from("net"),
         perm(
-            &[
-                "std::net",
-                "std::os::linux::net",
-                "std::os::wasi::net",
-                "std::os::windows::net",
-            ],
+            &["std::net", "std::os::linux::net", "std::os::windows::net"],
             &[],
         ),
     );

--- a/src/config/built_in.rs
+++ b/src/config/built_in.rs
@@ -10,14 +10,17 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
         perm(
             &[
                 "std::fs",
-                "std::os::darwin::fs",
+                // Darwin is not yet supported
+                //"std::os::darwin::fs",
                 "std::os::linux::fs",
                 "std::os::unix::fs",
                 "std::os::unix::io",
-                "std::os::wasi::fs",
-                "std::os::wasi::io",
-                "std::os::windows::fs",
-                "std::os::windows::io",
+                // WASI is not yet supported
+                //"std::os::wasi::fs",
+                //"std::os::wasi::io",
+                // Windows is not yet supported
+                //"std::os::windows::fs",
+                //"std::os::windows::io",
                 "std::path",
             ],
             &[],
@@ -27,7 +30,12 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
     result.insert(
         ApiName::from("net"),
         perm(
-            &["std::net", "std::os::linux::net", "std::os::windows::net"],
+            &[
+                "std::net",
+                "std::os::linux::net",
+                // Windows is not yet supported
+                //"std::os::windows::net",
+            ],
             &[],
         ),
     );
@@ -42,7 +50,8 @@ pub(crate) fn get_built_ins() -> BTreeMap<ApiName, ApiConfig> {
                 "std::process",
                 "std::os::linux::process",
                 "std::unix::process",
-                "std::windows::process",
+                // Windows is not yet supported
+                //"std::windows::process",
             ],
             &["std::process::abort", "std::process::exit"],
         ),


### PR DESCRIPTION
Partially solves #48 (points 1-3)

Builds on #54, so should be merged afterwards.

The update of the `cackle.toml` can only happen after the next release as otherwise the CI will fail.