### PR TITLE
Remove unused APIs that were erroneously added in 0.9.0

### DIFF
--- a/cackle.toml
+++ b/cackle.toml
@@ -224,9 +224,6 @@ allow_unsafe = true
 
 [pkg.toml_edit]
 allow_unsafe = true
-allow_apis = [
-    "fs",
-]
 
 [pkg.memchr]
 allow_unsafe = true
@@ -311,9 +308,6 @@ allow_unsafe = true
 
 [pkg.getrandom]
 allow_unsafe = true
-build.allow_apis = [
-    "process",
-]
 
 [pkg.serde_core]
 allow_unsafe = true
@@ -402,8 +396,3 @@ allow_unsafe = true
 
 [pkg.time]
 allow_unsafe = true
-
-[pkg.paste]
-build.allow_apis = [
-    "process",
-]


### PR DESCRIPTION
See title

Fixes the warnings in the actions