### PR TITLE
fix: Properly handle non-ASCII characters in V0 mangled symbols

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -640,7 +640,7 @@ mod tests {
                 exclude = [
                     "std::env::var",
                 ]
-                
+
                 [api.env]
                 include = ["std::env"]
 

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -191,7 +191,7 @@ impl<'data> Iterator for DemangleIterator<'data> {
                                 }
                                 b'S' => {
                                     // Shim : symbol added by the compiler when an intermediate is needed
-                                    set_remaining!(&rest[1..]);
+                                    // Just skip it (one character)
                                     return self.next();
                                 }
                                 _ => {

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -122,7 +122,7 @@ fn parse_undisambiguated_identifier(data: &str) -> Option<(&str, &str)> {
 
     // Decimal length followed by that many bytes
     let (len, rest) = parse_decimal(rest)?;
-    
+
     // In the case where the bytes start with a number, an underscore is added to distinguish decimal-number and bytes
     let rest = rest.strip_prefix('_').unwrap_or(rest);
 
@@ -804,36 +804,35 @@ mod tests {
     fn check_identifier(mangled: &str, expected: &str) {
         if let Some((ident, _)) = parse_identifier(mangled) {
             assert_eq!(ident, expected);
-        }
-        else {
+        } else {
             panic!("Empty was returned during parsing");
         }
     }
 
     #[test]
-    fn test_identifier_no_disambiguator(){
-        check_identifier("7mycrate", "mycrate")        
+    fn test_identifier_no_disambiguator() {
+        check_identifier("7mycrate", "mycrate")
     }
 
     #[test]
-    fn test_identifier_with_disambiguator_(){
-        check_identifier("s15kBYyAo9fc_7mycrate", "mycrate")        
+    fn test_identifier_with_disambiguator_() {
+        check_identifier("s15kBYyAo9fc_7mycrate", "mycrate")
     }
 
     #[test]
-    fn test_identifier_with_punycode(){
+    fn test_identifier_with_punycode() {
         // Original identifier is "gödel"
-        check_identifier("u8gdel_5qa", "gdel_5qa")        
+        check_identifier("u8gdel_5qa", "gdel_5qa")
     }
 
     #[test]
-    fn test_identifier_with_ambiguous_length(){
-        check_identifier("4_2zip", "2zip")        
+    fn test_identifier_with_ambiguous_length() {
+        check_identifier("4_2zip", "2zip")
     }
 
     #[test]
-    fn test_identifier_punnycode_with_ambiguous_length(){
-        // Original identifier is "ρυστ"        
-        check_identifier("u6_2xaedc", "2xaedc")        
+    fn test_identifier_punnycode_with_ambiguous_length() {
+        // Original identifier is "ρυστ"
+        check_identifier("u6_2xaedc", "2xaedc")
     }
 }

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -117,33 +117,14 @@ fn parse_disambiguator(data: &str) -> Option<&str> {
 }
 
 fn parse_undisambiguated_identifier(data: &str) -> Option<(&str, &str)> {
-    // Check for punycode (u followed by decimal length)
-    if let Some(rest) = data.strip_prefix('u') {
-        if let Some((len, rest)) = parse_decimal(rest) {
-            // Punycode identifier - for simplicity, we'll just extract the raw bytes
+    // Remove the 'u' prefix if punnycode (no difference with regular case : we extract the bytes)
+    let rest = data.strip_prefix('u').unwrap_or(data);
 
-            // In the case where the bytes start with a number, an underscore is added to distinguish decimal-number and bytes
-            let rest = match rest.strip_prefix('_') {
-                Some(new_rest) => new_rest,
-                None => rest,
-            };
-
-            if len as usize <= rest.len() {
-                let (ident, rest) = rest.split_at(len as usize);
-                return Some((ident, rest));
-            }
-        }
-        return None;
-    }
-
-    // Regular identifier: decimal length followed by that many bytes
-    let (len, rest) = parse_decimal(data)?;
+    // Decimal length followed by that many bytes
+    let (len, rest) = parse_decimal(rest)?;
     
     // In the case where the bytes start with a number, an underscore is added to distinguish decimal-number and bytes
-    let rest = match rest.strip_prefix('_') {
-        Some(new_rest) => new_rest,
-        None => rest,
-    };
+    let rest = rest.strip_prefix('_').unwrap_or(rest);
 
     if len as usize <= rest.len() {
         let (ident, rest) = rest.split_at(len as usize);

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -119,10 +119,15 @@ fn parse_disambiguator(data: &str) -> Option<&str> {
 fn parse_undisambiguated_identifier(data: &str) -> Option<(&str, &str)> {
     // Check for punycode (u followed by decimal length)
     if let Some(rest) = data.strip_prefix('u') {
-        if let Some((len, rest)) = parse_decimal(rest)
-            && let Some(rest) = rest.strip_prefix('_')
-        {
+        if let Some((len, rest)) = parse_decimal(rest) {
             // Punycode identifier - for simplicity, we'll just extract the raw bytes
+
+            // In the case where the bytes start with a number, an underscore is added to distinguish decimal-number and bytes
+            let rest = match rest.strip_prefix('_') {
+                Some(new_rest) => new_rest,
+                None => rest,
+            };
+
             if len as usize <= rest.len() {
                 let (ident, rest) = rest.split_at(len as usize);
                 return Some((ident, rest));
@@ -133,6 +138,13 @@ fn parse_undisambiguated_identifier(data: &str) -> Option<(&str, &str)> {
 
     // Regular identifier: decimal length followed by that many bytes
     let (len, rest) = parse_decimal(data)?;
+    
+    // In the case where the bytes start with a number, an underscore is added to distinguish decimal-number and bytes
+    let rest = match rest.strip_prefix('_') {
+        Some(new_rest) => new_rest,
+        None => rest,
+    };
+
     if len as usize <= rest.len() {
         let (ident, rest) = rest.split_at(len as usize);
         Some((ident, rest))
@@ -797,5 +809,45 @@ mod tests {
         assert!(actual.contains(&"core".to_string()));
         assert!(actual.contains(&"ptr".to_string()));
         assert!(!actual.contains(&"::".to_string()));
+    }
+
+    // +----------------------------------------+
+    // | Tests on the parsing of the identifier |
+    // +----------------------------------------+
+
+    fn check_identifier(mangled: &str, expected: &str) {
+        if let Some((ident, _)) = parse_identifier(mangled) {
+            assert_eq!(ident, expected);
+        }
+        else {
+            panic!("Empty was returned during parsing");
+        }
+    }
+
+    #[test]
+    fn test_identifier_no_disambiguator(){
+        check_identifier("7mycrate", "mycrate")        
+    }
+
+    #[test]
+    fn test_identifier_with_disambiguator_(){
+        check_identifier("s15kBYyAo9fc_7mycrate", "mycrate")        
+    }
+
+    #[test]
+    fn test_identifier_with_punycode(){
+        // Original identifier is "gödel"
+        check_identifier("u8gdel_5qa", "gdel_5qa")        
+    }
+
+    #[test]
+    fn test_identifier_with_ambiguous_length(){
+        check_identifier("4_2zip", "2zip")        
+    }
+
+    #[test]
+    fn test_identifier_punnycode_with_ambiguous_length(){
+        // Original identifier is "ρυστ"        
+        check_identifier("u6_2xaedc", "2xaedc")        
     }
 }

--- a/src/demangle.rs
+++ b/src/demangle.rs
@@ -189,6 +189,11 @@ impl<'data> Iterator for DemangleIterator<'data> {
                                     // Crate root in path
                                     return self.next();
                                 }
+                                b'S' => {
+                                    // Shim : symbol added by the compiler when an intermediate is needed
+                                    set_remaining!(&rest[1..]);
+                                    return self.next();
+                                }
                                 _ => {
                                     // Try to parse as identifier directly
                                     if let Some((ident, new_rest)) = parse_identifier(rest) {


### PR DESCRIPTION
Cackle's current demangler implements wrongly [this rule](https://doc.rust-lang.org/rustc/symbol-mangling/v0.html#identifier) : the optional underscore is always parsed as `bytes`.

### Example 
If a user sets a custom API on a function / a crate called `ρυστ`, cackle ignores it because its mangled identifier is `u6_2xaedc` and cackle parses `_2xaedc` instead of `2xaedc`.

### Fix
Correctly implement this rule (I also factorised the code as it was the same with and without punnycode)

Other : skip the `S` in case of a shim (see [this rule](https://doc.rust-lang.org/rustc/symbol-mangling/v0.html#path-nested-path))